### PR TITLE
Added fields to package.json for type support and other environments

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -2,13 +2,11 @@
   "name": "proxy-deep",
   "version": "4.0.0",
   "description": "A Proxy object that can nest itself when accessed",
-  "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",
   "exports": {
     "types": "./index.d.ts",
-    "import": "./index.mjs",
-    "require": "./index.js"
+    "import": "./index.mjs"
   },
   "scripts": {
     "prepare": "tsc",

--- a/package/package.json
+++ b/package/package.json
@@ -2,7 +2,11 @@
   "name": "proxy-deep",
   "version": "4.0.0",
   "description": "A Proxy object that can nest itself when accessed",
+  "main": "./index.js",
+  "module": "./index.mjs",
+  "types": "./index.d.ts",
   "exports": {
+    "types": "./index.d.ts",
     "import": "./index.mjs",
     "require": "./index.js"
   },


### PR DESCRIPTION
This is a tiny change to the package.json to ensure type definitions in the package are utilized (currently missing).

I also added the `.module` field for support in other environments and removed the `.exports.require` field since the module is now ESM (previously pointed to a missing file).